### PR TITLE
Fixing a failure seen in `MessageIdFactoryTest.java`

### DIFF
--- a/cat-client/src/test/java/com/dianping/cat/message/context/MessageIdFactoryTest.java
+++ b/cat-client/src/test/java/com/dianping/cat/message/context/MessageIdFactoryTest.java
@@ -102,12 +102,15 @@ public class MessageIdFactoryTest extends ComponentTestCase {
 
 		pool.shutdown();
 		pool.awaitTermination(2000, TimeUnit.MILLISECONDS);
-
-		int total = threads * messagesPerThread;
-
-		Assert.assertEquals("Not all threads completed in time.", total, ids.size());
-		Assert.assertEquals(true, ids.contains(String.format("default-parallel-c0a81f9e-403215-%s", total - 1)));
-		Assert.assertEquals(String.format("default-parallel-c0a81f9e-403215-%s", total), factory.getNextId());
+		boolean finished = pool.awaitTermination(1, TimeUnit.HOURS);
+		if (finished) {
+			int total = threads * messagesPerThread;
+			Assert.assertEquals("Not all threads completed in time.", total, ids.size());
+			Assert.assertEquals(true, ids.contains(String.format("default-parallel-c0a81f9e-403215-%s", total - 1)));
+			Assert.assertEquals(String.format("default-parallel-c0a81f9e-403215-%s", total), factory.getNextId());
+		} else {
+			Assert.fail("Threads did not finish in 1 hour");
+		}
 	}
 
 	@Test
@@ -135,13 +138,16 @@ public class MessageIdFactoryTest extends ComponentTestCase {
 
 		pool.shutdown();
 		pool.awaitTermination(2000, TimeUnit.MILLISECONDS);
-
-		int total = threads * messagesPerThread;
-
-		Assert.assertEquals("Not all threads completed in time.", total, ids.size());
-		Assert.assertEquals(true, ids.contains(String.format("given-parallel-c0a81f9e-403215-%s", total - 1)));
-		Assert.assertEquals(String.format("given-parallel-c0a81f9e-403215-%s", total),
-		      factory.getNextId("given-parallel"));
+		boolean finished = pool.awaitTermination(1, TimeUnit.HOURS);
+		if (finished) {
+			int total = threads * messagesPerThread;
+			Assert.assertEquals("Not all threads completed in time.", total, ids.size());
+			Assert.assertEquals(true, ids.contains(String.format("given-parallel-c0a81f9e-403215-%s", total - 1)));
+			Assert.assertEquals(String.format("given-parallel-c0a81f9e-403215-%s", total),
+					factory.getNextId("given-parallel"));
+		} else {
+			Assert.fail("Threads did not finish in 1 hour");
+		}
 	}
 
 	@Test


### PR DESCRIPTION
In `MessageIdFactoryTest.java`, the following test has been found to be flaky:

- `com.dianping.cat.message.context.MessageIdFactoryTest.testGivenDomainInParallel`.

**REASON FOR FLAKINESS:**

- The mentioned test is not waiting for all the threads to complete execution.
- The execution of this test depends on `com.dianping.cat.message.context.MessageIdFactoryTest.testDefaultDomainInParallel` and a similar behaviour is observed in this test as well.

**DETECTING THE FLAKINESS:**

I used the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool to verify the flakiness in both the mentioned tests. The steps that can be used to verify the same are as follows:

1. `git clone https://github.com/dianping/cat`.
2. `mvn -pl cat-client install`.
3. `mvn -pl cat-client edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.dianping.cat.message.context.MessageIdFactoryTest#testGivenDomainInParallel`.

After executing these steps, the following error will be hit:

```
 T E S T S
-------------------------------------------------------
Concurrency config is parallel='none', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
Running com.dianping.cat.message.context.MessageIdFactoryTest
Tests run: 6, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: -289,157.592 sec <<< FAILURE!

Results :

Failed tests:   testDefaultDomainInParallel(com.dianping.cat.message.context.MessageIdFactoryTest): Not all threads completed in time. expected:<123400> but was:<38720>
  testGivenDomainInParallel(com.dianping.cat.message.context.MessageIdFactoryTest): Not all threads completed in time. expected:<123400> but was:<29820>

Tests run: 6, Failures: 2, Errors: 0, Skipped: 0
```

**PROPOSED SOLUTION:**

- The fix involves waiting for all the threads to complete their executions.
- We can initiate a wait for all jobs to be done using `pool.awaitTermination(1, TimeUnit.HOURS);`.
- Once all jobs and threads have completed execution, we can proceed to the assertions.
- This way assertions will not fail owing to an inadequate wait time for job completion.